### PR TITLE
Implemented pagination parameters

### DIFF
--- a/src/middleware/paginate.js
+++ b/src/middleware/paginate.js
@@ -13,7 +13,10 @@ var _ = require('underscore'),
  * @since 0.2.0
  * @beta
  * @example
- *  var paginate = require('contxt-sdk-nodejs').Sdk().middleware.Paginate({});
+ *  var paginate = require('contxt-sdk-nodejs').Sdk().middleware.Paginate({
+ *    limit: 10,
+ *    offset: 0
+ *  });
  */
 
 var Paginate = function(options) {
@@ -22,7 +25,10 @@ var Paginate = function(options) {
    * @private
    * @type object
    */
-  var _options = _.defaults(options, {});
+  var _options = _.defaults(options, {
+    limit: 10,
+    offset: 0
+  });
 
   /**
    * Handle pagination based on req values.
@@ -34,40 +40,35 @@ var Paginate = function(options) {
    * @param {function} next - Callback to execute the next Express middleware.
    */
   var paginate = function(req, res, next) {
-    req.pagination = {};
+    req.pagination = {
+      limit: _options.limit,
+      offset: _options.offset
+    };
+
+    if (_.has(req.filters, 'limit')) {
+      req.pagination.limit = parseInt(req.filters.limit);
+
+      delete req.filters.limit;
+    }
 
     if (_.has(req.filters, 'offset')) {
       req.pagination.offset = req.filters.offset;
 
       delete req.filters.offset;
-    } else {
-      req.pagination.offset = 0;
-    }
-
-    if (_.has(req.filters, 'limit')) {
-      req.pagination.limit = parseInt(req.filters.limit);
-
-      if (!req.pagination.limit) {
-        return next(new errors.validation_error('limit must be a number between 0 and 100'));
-      }
-
-      if (req.pagination.limit > 100) {
-        return next(new errors.validation_error('limit cannot be greater than 100'));
-      }
-
-      if (req.pagination.limit <= 0) {
-        return next(new errors.validation_error('limit cannot be 0 or less'));
-      }
-
-      delete req.filters.limit;
-    } else {
-      req.pagination.limit = 10;
     }
 
     if (_.has(req.filters, 'orderBy')) {
       req.pagination.orderBy = req.filters.orderBy;
 
       delete req.filters.orderBy;
+    }
+
+    if (req.pagination.limit > 100) {
+      return next(new errors.validation_error('limit cannot be greater than 100'));
+    }
+
+    if (req.pagination.limit <= 0) {
+      return next(new errors.validation_error('limit cannot be 0 or less'));
     }
 
     next();

--- a/src/middleware/paginate.js
+++ b/src/middleware/paginate.js
@@ -5,6 +5,8 @@ var _ = require('underscore'),
  * @class Paginate
  * @constructor
  * @param {object} options - The options.
+ * @param {string} options.limit - The pagination limit.
+ * @param {string} options.offset - The pagination offset.
  * @static
  * @module middleware
  * @submodule paginate


### PR DESCRIPTION
Added two default parameters for the `paginate` middleware:

`var paginate = require('contxt-sdk-nodejs').Sdk().middleware.Paginate({limit: 10, offset: 0});`